### PR TITLE
Add placeholders and selectable options in the form section

### DIFF
--- a/front/src/components/MainSc.jsx
+++ b/front/src/components/MainSc.jsx
@@ -51,6 +51,10 @@ export function MainSc() {
     setShowForm(true);
   };
   return (
+
+    // Code Review: I would suggest consider adding placeholders in the form input fields
+    // And provide selectable options for inputs requiring a True/False or Date response
+    
     <>
       <button onClick={handleButtonClick} disabled={loading}>
         Create a new Bank account Info


### PR DESCRIPTION
In the 'Create a New Bank Account' section, I would suggest to  add placeholders in the form input fields. These placeholders can guide users on what type of information to input.  Additionally, it would be more user-friendly to provide selectable options for inputs requiring a True/False or Date response, such as dropdown menus instead of plain text input.